### PR TITLE
fixed company title's word wrapping

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -18,6 +18,7 @@
     display: flex;
     align-items: center;
     padding: 30px;
+    word-wrap: break-word;
 
     span {
       width: 140px;

--- a/app/views/job_applications/show.html.erb
+++ b/app/views/job_applications/show.html.erb
@@ -49,9 +49,6 @@
           <i class="impression">Your impression</i>
           <p><%= @job_application.your_impression %></p>
         </div>
-        <div>
-
-        </div>
       </div>
 
 


### PR DESCRIPTION
Fixed the word wrapping. Please keep in mind that it does not work for single words that are too long, e.g.: fussbodenschleifmaschinenverleih was my example

<img width="927" alt="Screen Shot 2019-12-05 at 18 04 32" src="https://user-images.githubusercontent.com/48135513/70256932-b2721200-1789-11ea-89b5-0ca3166a283a.png">
